### PR TITLE
提高表情标签清洗优先级

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -56,7 +56,7 @@
   "emotion_prompt_template": {
     "type": "text",
     "description": "追加到 system_prompt 的提示，可用 {tags} 代表全部标签",
-    "default": "当你回答时，请根据文本情绪，在回答正文最前面插入一个情绪标签，包括且仅限 {tags} 中的一个。标签不得含有其他符号，不得在句中插入，只能在句首插入。"
+    "default": "请在每一次回复的开头添加一条情绪标签（包括且仅限 {tags} 中的一个）作为文本前缀。【警告⚠️】：工具调用响应时切勿添加表情标签！！！"
   },
 
   "webui_enabled": {


### PR DESCRIPTION
原标清标签在`@filter.on_decorating_result(priority=-10)`中被清洗，其他调用`@filter.on_llm_response()`钩子获取响应结果的插件得到的是未清洗的结果；

现在将表情清洗放到`@filter.on_llm_response()`，提高此钩子优先级至极大值，同时在这里通过`event.set_extra("extracted_emotion_tag", emotion_tag)`保存表情标签以供`@filter.on_decorating_result()`渲染使用。

检测下来清洗正常，表情表情提取与渲染均正常；其他插件获取`@filter.on_llm_response()`文本无表情标签。


此外，改进默认提示词，更加简洁且针对性（称为前进“前缀”）；强调工具调用不可使用表情标签，因为工具调用响应的标签标签并不会被清洗。