### PR TITLE
多张图片允许合并发送

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,10 +23,22 @@
     "default": false
   },
 
-  "image_type": {
-    "type": "string",
-    "description": "渲染输出格式，png 或 jpeg",
-    "default": "png"
+  "merge_split_images": {
+    "type": "bool",
+    "description": "合并分割渲染的图片为一张（需启用超长文本智能分割渲染）",
+    "default": true
+  },
+
+  "merge_max_images": {
+    "type": "int",
+    "description": "每批最多合并几张图片（默认5张）",
+    "default": 5
+  },
+
+  "image_quality": {
+    "type": "int",
+    "description": "JPEG图片质量（1-100，默认85）",
+    "default": 85
   },
 
   "font_path": {


### PR DESCRIPTION
### 新增功能

为了避免长文本分割之后发送过多图片导致刷屏，新增发送图片合并功能，将文本分割后的渲染的多张图片按照顺序从上往下拼接渲染并发送。

### 配置方式

在插件配置中新增图片合并相关配置项：

1. merge_split_images（默认 false）：

- 开启时：多张分割图片自动合并为单张发送

- 关闭时：多张分割图片按顺序逐张发送

2. merge_max_images（默认 5）：设置每批次最大合并图片数量

3. image_quality（默认 85）：设置 JPEG 输出质量（1-100）

移除原有的 `image_type` 配置项，统一使用 JPEG 格式输出使其可以进行图片压缩

